### PR TITLE
Add React v15 support

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -4,6 +4,9 @@ function registerDeclaration() {
       conditions: [
         new chrome.declarativeContent.PageStateMatcher({
           css: ['[data-reactid]']
+        }),
+        new chrome.declarativeContent.PageStateMatcher({
+          css: ['[data-reactroot]']
         })
       ],
       actions: [new chrome.declarativeContent.ShowPageAction() ]

--- a/js/highlight.js
+++ b/js/highlight.js
@@ -15,7 +15,7 @@ if (style) {
     0
   );
   style.sheet.insertRule(
-    '[data-reactid] { \
+    '[data-reactid],[data-reactroot] { \
         color: #000 !important; \
         background-color: rgba(178, 233, 247, 0.4) !important; \
         animation: shadowlicious ease-in-out 2.5s infinite; \


### PR DESCRIPTION
Adds React v15 support using `data-reactroot` alongside the previous `data-react-id`. Although, this can't highlight each of the components by design, at least this enhances the extension to support and highlight root React components.